### PR TITLE
Fixes 'cannot run a command inside the new session' error

### DIFF
--- a/yaknewtab
+++ b/yaknewtab
@@ -173,7 +173,7 @@ init_ipc_interface() {
     }
 
     yakuake_runcommand() {
-      "$dbus_cmd" org.kde.yakuake /yakuake/sessions org.kde.yakuake.runCommandInTerminal "$1" >/dev/null
+      "$dbus_cmd" org.kde.yakuake /yakuake/sessions runCommand "$1" > /dev/null
     }
 
     yakuake_settitle() {


### PR DESCRIPTION
Hi,

on Fedora-36, the command is not executed and I'm getting this ERROR:

```
cannot run a command inside the new session.
```
I'm using this command:
```
./yaknewtab  --noclose --debug -e date
```

and I'm getting 
```
Invalid number of parameters
```
on the console. 

This patch fixes the problem. Could you please review it and consider to merge it? 

Thanks a lot!
Jirka
